### PR TITLE
Connect ui to acid-api

### DIFF
--- a/client/assets/js/app.js
+++ b/client/assets/js/app.js
@@ -68,7 +68,8 @@
       $rootScope.$stateParams = $stateParams;
   }])
 
-  app.controller("projectsController", function ($scope, $http) {
+  app.controller("projectsController", ['$scope', '$stateParams', '$http',
+       function ($scope, $stateParams, $http) {
     $http({
       method: 'GET',
       url: 'https://cors-anywhere.herokuapp.com/http://acid-api.technosophos.me:7745/v1/projects',
@@ -82,7 +83,7 @@
     },
       function errorCallback(response) {}
     );
-  });
+  }]);
 
   app.controller("projectController", ['$scope', '$stateParams', '$http',
        function ($scope, $stateParams, $http) {
@@ -98,6 +99,9 @@
       }
     }).then(function successCallback(response) {
         $scope.project = response.data;
+
+        var projectID = $scope.project.name;
+        console.log('the project is ' + projectID );
     },
       function errorCallback(response) {}
     );

--- a/client/index.html
+++ b/client/index.html
@@ -32,12 +32,12 @@
     </div>
 
     <!-- left sidebar -->
-    <div zf-panel position="left" id="sidebar" class="medium-grid-block collapse medium-2 large-2 vertical" ng-hide="$state.current.name === 'home'">
+    <div zf-panel position="left" id="sidebar" class="medium-grid-block collapse medium-2 large-2 vertical" ng-hide="$state.current.name === 'home'" ng-init="projectID={{project.id}}">
       <div class="grid-content collapse shrink">
         <ul class="menu-bar primary">
           <li id="organization" ng-controller="projectController">
             <a href="" zf-popup-toggle="switcher">
-              <h2>{{ $stateParams.id | trim }}</h2>
+              <h2>{{ $stateParams | trim }}</h2>
               <h3>Azure Container Service</h3>
 
               <i class="icon ion-chevron-down right"></i>

--- a/client/templates/project.html
+++ b/client/templates/project.html
@@ -84,6 +84,9 @@ Events:
   <ul class="grid-content build-list collapse" ng-controller="buildsController">
     <li ng-repeat="build in builds" class="medium-grid-block build-item">
       <a href="../acid-ui/#!/build/{{build.id}}" class="grid-block">
+
+        <!-- <h1>H1 {{build.worker}}</h1> -->
+
         <div class="act-state collapse {{ build.worker.status }}" ng-class="{
           'success': build.worker.status == 'Succeeded',
           'failed': build.worker.status == 'Failed',
@@ -100,8 +103,8 @@ Events:
           {{ build.id }}
         </div>
         <div class="act-hash small-2 collapse">{{build.commit | limitTo : -6: number.length }}</div>
-        <div class="act-time-ago small-1 collapse">{(timeago)}</div>
-        <div class="act-time-duration small-1 collapse">{(duration)}</div>
+        <div class="act-time-ago small-1 collapse">{{ build.worker.start_time }}</div>
+        <div class="act-time-duration small-1 collapse">{{ build.worker.start_time }}</div>
         <!-- <div class="act-child-jobs small-2 collapse">
           {{ build.jobs.length }}
         </div> -->


### PR DESCRIPTION
![api-wip](https://user-images.githubusercontent.com/686194/29953468-4d27c302-8e85-11e7-9feb-fb017eee5515.gif)

I've scoped the `project/:id` and `build/:id` endpoints here, but haven't been able to get build > task logs into the UI yet. 

# Issues

* The UI throws 404 errors for the API endpoints in development - `Access-Control-Allow-Origin` errors when fetching the `acid-api` server - **can we add headers to the api**? In the meantime, I used [this plugin](https://chrome.google.com/webstore/detail/allow-control-allow-origi/nlfbmbojpeacfghkpbjhddihlkkiljbi?hl=en) to get around it.
* Fetching the tasks and logs - I'm not sure how to get these endpoints.
  @bacongobbler I'll need your help to point them out - then I can wire up the streaming:
  `localhost:7745/v1/task/{{ task.id }}/logs?stream=true`

* Can we **fetch indexes** for projects, builds, tasks, etc in `acid-api`? As it stands I don't think we have that functionality. Ideally the UI would be able to use angular's ngRepeat to show things like:

```
dashboard:     |  {{ project in account.projects }}
project view:  |  |  {{ build in project.builds }}
build view:    |  |  |  {{ job in build.jobs }} 
               |  |  |  {{ task.log in job.tasks }} 
```