### PR TITLE
Add chart and Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,6 @@
-FROM node:boron
+FROM nginx:stable-alpine
 
-RUN apt-get clean && apt-get update
-RUN apt-get install -y curl
+COPY dist/* /usr/share/nginx/html/
 
-# Create app directory
-RUN mkdir -p /usr/src/app
-WORKDIR /usr/src/app
-
-# Installing nodesjs
-# RUN curl -sL https://deb.nodesource.com/setup_7.x | bash
-# RUN apt-get install -y nodejs
-
-# Install app dependencies
-COPY package.json .
-COPY bower.json .
-
-RUN npm install --quiet -g foundation-cli gulp bower && npm cache clean
-RUN npm install --quiet
-RUN bower install --allow-root
-
-# Bundle app source
-COPY . .
-
-CMD [ "npm", "start" ]
-EXPOSE 4000
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/README.md
+++ b/README.md
@@ -22,3 +22,21 @@ npm start
 
 The UI prototype is deployed via a `gulp deploy`.
 
+## Kubernetes Installation
+
+To install the Brigade UI to a Kubernetes cluster:
+
+1. Ensure that Brigade is already running
+2. Install the chart: `helm install chart/kashti`
+
+If you are running Minikube, you can do a full build of this repo into a Docker
+image:
+
+```
+$ eval $(minikube docker-env)
+$ npm docker-build
+$ helm install -n brigade-ui chart/kashti
+```
+
+This will push a copy of the Docker image into your Minikube docker registry and
+then install the chart.

--- a/chart/kashti/.helmignore
+++ b/chart/kashti/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/chart/kashti/Chart.yaml
+++ b/chart/kashti/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+description: A Helm chart for Kubernetes
+name: kashti
+version: 0.1.0

--- a/chart/kashti/templates/NOTES.txt
+++ b/chart/kashti/templates/NOTES.txt
@@ -1,0 +1,17 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.hostname }}
+  http://{{- .Values.ingress.hostname }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get svc -w {{ template "fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP:{{ .Values.service.externalPort }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl port-forward $POD_NAME 8080:{{ .Values.service.externalPort }}
+{{- end }}

--- a/chart/kashti/templates/_helpers.tpl
+++ b/chart/kashti/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/chart/kashti/templates/deployment.yaml
+++ b/chart/kashti/templates/deployment.yaml
@@ -1,0 +1,37 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "name" . }}
+        release: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.service.internalPort }}
+          livenessProbe:
+            httpGet:
+              path: /
+              port: {{ .Values.service.internalPort }}
+          readinessProbe:
+            httpGet:
+              path: /
+              port: {{ .Values.service.internalPort }}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+    {{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+    {{- end }}

--- a/chart/kashti/templates/ingress.yaml
+++ b/chart/kashti/templates/ingress.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.ingress.enabled -}}
+{{- $serviceName := include "fullname" . -}}
+{{- $servicePort := .Values.service.externalPort -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    {{- range $key, $value := .Values.ingress.annotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  rules:
+    {{- range $host := .Values.ingress.hosts }}
+    - host: {{ $host }}
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: {{ $serviceName }}
+              servicePort: {{ $servicePort }}
+    {{- end -}}
+  {{- if .Values.ingress.tls }}
+  tls:
+{{ toYaml .Values.ingress.tls | indent 4 }}
+  {{- end -}}
+{{- end -}}

--- a/chart/kashti/templates/service.yaml
+++ b/chart/kashti/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.externalPort }}
+      targetPort: {{ .Values.service.internalPort }}
+      protocol: TCP
+      name: {{ .Values.service.name }}
+  selector:
+    app: {{ template "name" . }}
+    release: {{ .Release.Name }}

--- a/chart/kashti/values.yaml
+++ b/chart/kashti/values.yaml
@@ -1,0 +1,37 @@
+# Default values for kashti.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+replicaCount: 1
+image:
+  repository: technosophos/kashti
+  tag: latest
+  pullPolicy: IfNotPresent
+service:
+  name: kashti
+  type: LoadBalancer
+  externalPort: 80
+  internalPort: 80
+ingress:
+  enabled: false
+  # Used to create Ingress record (should used with service.type: ClusterIP).
+  hosts:
+    - chart-example.local
+  annotations:
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  tls:
+    # Secrets must be manually created in the namespace.
+    # - secretName: chart-example-tls
+    #   hosts:
+    #     - chart-example.local
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious 
+  # choice for the user. This also increases chances charts run on environments with little 
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following 
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  #requests:
+  #  cpu: 100m
+  #  memory: 128Mi

--- a/client/index.html
+++ b/client/index.html
@@ -7,7 +7,7 @@
 
   <title>Brigade UI</title>
 
-  <base href="/">
+  <base href="/brigade-ui/">
 
   <link href="assets/css/app.css" rel="stylesheet" type="text/css">
   <link rel="icon" type="image/png" href="assets/images/favicon.png">

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -157,6 +157,18 @@ gulp.task('base-local', function() {
     .pipe(gulp.dest('./client/'))
 });
 
+// Prep the templates for Docker build
+gulp.task('base-docker', function() {
+  return gulp.src('./client/index.html')
+    .pipe(replace('base href="/"', 'base href="/brigade-ui/"'))
+    .pipe(gulp.dest('./client/'))
+    .pipe(gulp.dest('./dist/'))
+});
+
+gulp.task('docker-build', function(cb) {
+  sequence('clean', 'base-docker', ['copy', 'copy:foundation', 'sass', 'uglify'], 'copy:templates', cb);
+});
+
 // Prep the templates for deploy to gh-pages
 gulp.task('base-prod', function() {
   return gulp.src('./client/index.html')

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "1.2.0",
   "scripts": {
     "start": "gulp",
-    "build": "gulp build --production"
+    "build": "gulp build --production",
+    "docker-build": "gulp docker-build && docker build -t technosophos/kashti:latest ."
   },
   "devDependencies": {
     "angular-cors": "^1.0.0",


### PR DESCRIPTION
This adds an nginx-based production-level docker image, and then
provides a Helm chart that can install this into a Kubernetes cluster

Closes #8
Closes #9