### PR TITLE
feat(chart): Make API server URL configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,12 @@ image:
 ```
 $ eval $(minikube docker-env)
 $ npm docker-build
-$ helm install -n brigade-ui chart/kashti
+$ helm install -n brigade-ui chart/kashti --set brigade.apiServer=https://example.com:7745
 ```
 
 This will push a copy of the Docker image into your Minikube docker registry and
 then install the chart.
+
+The value of `brigade.apiServer` should be the fully qualified URL to your Brigade
+installation's API server. This is the URL that the _client_ will see, so you
+may need to use the outside IP address, not the cluster IP.

--- a/chart/kashti/templates/configmap.yaml
+++ b/chart/kashti/templates/configmap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service }}
+data:
+  "settings.js": |-
+    const baseURL = '{{ default "http://localhost:7744" .Values.brigade.apiServer }}'
+    // End

--- a/chart/kashti/templates/deployment.yaml
+++ b/chart/kashti/templates/deployment.yaml
@@ -29,8 +29,15 @@ spec:
             httpGet:
               path: /
               port: {{ .Values.service.internalPort }}
+          volumeMounts:
+            - name: config-js
+              mountPath: /usr/share/nginx/html/js/settings
           resources:
 {{ toYaml .Values.resources | indent 12 }}
+      volumes:
+        - name: config-js
+          configMap:
+            name: {{ template "fullname" . }}
     {{- if .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}

--- a/chart/kashti/values.yaml
+++ b/chart/kashti/values.yaml
@@ -1,6 +1,6 @@
-# Default values for kashti.
-# This is a YAML-formatted file.
-# Declare variables to be passed into your templates.
+brigade:
+  apiServer: "http://localhost:7744"
+
 replicaCount: 1
 image:
   repository: technosophos/kashti


### PR DESCRIPTION
You can now set the API server URL in the chart.

Closes #13 
