### PR TITLE
display duration of a build, using amDifference

### DIFF
--- a/client/assets/js/app.js
+++ b/client/assets/js/app.js
@@ -137,7 +137,7 @@
       },
       isArray: true
     }).then(function successCallback(response) {
-        $scope.build = response.data;
+      $scope.build = response.data;
     },
       function errorCallback(response) {}
     );

--- a/client/assets/scss/_brigade-project.scss
+++ b/client/assets/scss/_brigade-project.scss
@@ -327,8 +327,7 @@
         min-width: 11%;
       }
       .act-time-ago {
-        min-width: 10%;
-
+        min-width: 18%;
       }
       .act-time-duration {
         min-width: 10%;

--- a/client/templates/project.html
+++ b/client/templates/project.html
@@ -151,14 +151,13 @@ controller: projectController
               <span class="act-message">
                 <em>#</em>{{build.id | limitTo:34 }}<small ng-if="build.id.length > 34">&#8230;</small>
               </span>
-              <span class="act-time-ago small-3 collapse">
-                Finished <span am-time-ago="build.worker.end_time"></span>.
-
-                <!--Ran for {{build.worker.start_time | amDurationFormat : 'minute' }}
-                {{ dateFrom | amDifference : dateTo : 'days' }}
-                {{ build.worker.start_time | date:'dd-M-yyyy H:mm Z' }} to {{ build.worker.end_time | date:'dd-M-yyyy H:mm Z'}}-->
+              <span class="act-time-ago">
+                {{build.worker.status}} <span am-time-ago="build.worker.end_time"></span>.
               </span>
-              <!-- <div class="act-child-jobs small-2 collapse">
+              <span class="act-time-duration">
+                Ran for <span>{{ build.worker.end_time | amDifference : build.worker.start_time : 'seconds' }} seconds.</span>
+              </span>
+              <!-- <div class="act-child-jobs">
                 {{ build.jobs.length }}
               </div> -->
             </a>

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -45,7 +45,7 @@ var paths = {
     'bower_components/angular-resource/angular-resource.js',
     'bower_components/angular-highlightjs/angular-highlightjs.js',
     'bower_components/moment/min/moment.min.js',
-    'bower_components/angular-moment/angular-moment.min.js',
+    'bower_components/angular-moment/angular-moment.js',
     'bower_components/foundation-apps/js/vendor/**/*.js',
     'bower_components/foundation-apps/js/angular/**/*.js',
     '!bower_components/foundation-apps/js/angular/app.js'


### PR DESCRIPTION
This was meant to be included in [#46](https://github.com/deis/brigade-ui/pull/46), but I messed up.

Adds a filter to display the duration of a build:

![screen shot 2017-11-21 at 1 13 23 pm](https://user-images.githubusercontent.com/686194/33097482-30e3bfd2-cebf-11e7-8994-ea43e81e5655.png)
