### PR TITLE
fix(Dockerfile): Add redirect to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM nginx:stable-alpine
 
 RUN mkdir -p /usr/share/nginx/html/kashti
+COPY dist/redirect.html /usr/share/nginx/html/index.html
 COPY dist/index.html /usr/share/nginx/html/kashti
 COPY dist/assets/  /usr/share/nginx/html/kashti/assets/
 COPY dist/templates/  /usr/share/nginx/html/kashti/templates/

--- a/client/redirect.html
+++ b/client/redirect.html
@@ -1,0 +1,11 @@
+<html>
+  <head>
+    <title>Go to the Brigade Dashboard</title>
+  <script>
+  window.location.replace(window.location.href.replace(/index\.html/,"") + "/brigade-ui/")
+  </script>
+  </head>
+  <body>
+    Go to the <a href="/brigade-ui/">Brigade Dashboard</a>.
+  </body>
+</html>


### PR DESCRIPTION
This adds an index.html that does a client-side redirect to Kashti's
web UI. (Server-side redirects do not work because the server does not
know the correct hostname and port)