### PR TITLE
fix API server port

### DIFF
--- a/charts/kashti/values.yaml
+++ b/charts/kashti/values.yaml
@@ -1,5 +1,5 @@
 brigade:
-  apiServer: "http://localhost:7744"
+  apiServer: "http://localhost:7745"
 
 replicaCount: 1
 image:


### PR DESCRIPTION
brigade's API server listens on port 7745. port 7744 is for the gateway.