### PR TITLE
Automatically refresh the UI for dashboard, project, build, and job

### DIFF
--- a/src/app/build/build.component.ts
+++ b/src/app/build/build.component.ts
@@ -1,30 +1,45 @@
 import { Location } from '@angular/common';
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, OnDestroy } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { Build } from '../models/build';
 import { BuildLog } from '../models/build-log';
 import { BuildWorker } from '../models/build-worker';
-import { Job } from '../models/job';
+import { Job, JobStatus } from '../models/job';
 import { Revision } from '../models/revision';
+import { Subscription, interval } from 'rxjs';
+import { BuildService } from '../services/build/build.service';
+import { JobService } from '../services/job/job.service';
+import { startWith, switchMap } from 'rxjs/operators';
 
 @Component({
   selector: 'app-build',
   templateUrl: './build.component.html',
   styleUrls: ['./build.component.scss']
 })
-
-export class BuildComponent implements OnInit {
+export class BuildComponent implements OnInit, OnDestroy {
   build: Build;
   buildlogs: BuildLog;
   revision: Revision;
   worker: BuildWorker;
   jobs: Job[];
   location: Location;
+  subscriptions: Subscription[] = [];
 
-  constructor(private route: ActivatedRoute, location: Location) { this.location = location; }
+  constructor(
+    private route: ActivatedRoute,
+    location: Location,
+    private buildService: BuildService,
+    private jobService: JobService
+  ) {
+    this.location = location;
+  }
 
   backClicked() {
     this.location.back();
+  }
+
+  ngOnDestroy(): void {
+    this.unsubscribe();
   }
 
   ngOnInit() {
@@ -33,5 +48,63 @@ export class BuildComponent implements OnInit {
     this.revision = this.build.revision;
     this.worker = this.build.worker;
     this.jobs = this.route.snapshot.data['jobs'];
+
+    if (this.shouldUpdate()) {
+      this.updateBuild();
+    }
+  }
+
+  private updateBuild() {
+
+    this.subscriptions.push(interval(5000)
+      .pipe(
+        startWith(0),
+        switchMap(() => {
+          // keep updating until the build is no longer pending or running
+          if (!this.shouldUpdate()) {
+            this.unsubscribe();
+          }
+          return this.buildService.getBuildLog(this.build.id);
+        })
+      )
+      .subscribe(res => (this.buildlogs = res)));
+
+    this.subscriptions.push(interval(5000)
+      .pipe(
+        startWith(0),
+        switchMap(() => {
+          // keep updating until the build is no longer pending or running
+          if (!this.shouldUpdate()) {
+            this.unsubscribe();
+          }
+          return this.buildService.getBuild(this.build.id);
+        })
+      )
+      .subscribe(res => (this.build = res)));
+
+    this.subscriptions.push(interval(5000)
+      .pipe(
+        startWith(0),
+        switchMap(() => {
+          // keep updating until the build is no longer pending or running
+          if (!this.shouldUpdate()) {
+            this.unsubscribe();
+          }
+          return this.jobService.getJobs(this.build.id);
+        })
+      )
+      .subscribe(res => (this.jobs = res)));
+  }
+
+  private shouldUpdate(): boolean {
+    return this.build.worker.status === JobStatus.Pending || this.build.worker.status === JobStatus.Running;
+  }
+
+  private unsubscribe(): void {
+    if (this.subscriptions) {
+      this.subscriptions.forEach(sub => {
+        sub.unsubscribe();
+      });
+    }
   }
 }

--- a/src/app/job/job.component.spec.ts
+++ b/src/app/job/job.component.spec.ts
@@ -1,6 +1,8 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { JobComponent } from './job.component';
+import { JobService } from '../services/job/job.service';
+import { LogService } from '../services/log/log.service';
 
 describe('JobComponent', () => {
   let component: JobComponent;
@@ -13,7 +15,8 @@ describe('JobComponent', () => {
           [{ path: '', component: JobComponent }]
         )
       ],
-      declarations: [JobComponent]
+      declarations: [JobComponent],
+      providers: [JobService, LogService]
     })
       .compileComponents();
   }));

--- a/src/app/job/job.component.ts
+++ b/src/app/job/job.component.ts
@@ -1,9 +1,14 @@
 import { Location } from '@angular/common';
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, OnDestroy } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import 'rxjs/add/operator/switchMap';
-import { Job } from '../models/job';
+import { Job, JobStatus } from '../models/job';
 import { Log } from '../models/log';
+import { interval, Subscription } from 'rxjs';
+import { startWith, switchMap, filter, take } from 'rxjs/operators';
+import { JobService } from '../services/job/job.service';
+import { LogService } from '../services/log/log.service';
+import { environment } from 'src/environments/environment';
 
 @Component({
   selector: 'app-job',
@@ -11,19 +16,75 @@ import { Log } from '../models/log';
   providers: [Location],
   styleUrls: ['../build/build.component.scss']
 })
-export class JobComponent implements OnInit {
+export class JobComponent implements OnInit, OnDestroy {
   job: Job;
   log: Log;
   location: Location;
+  subscriptions: Subscription[] = [];
 
-  constructor(private route: ActivatedRoute, location: Location) { this.location = location; }
+  constructor(
+    private route: ActivatedRoute,
+    location: Location,
+    private jobService: JobService,
+    private logService: LogService
+  ) {
+    this.location = location;
+  }
 
   backClicked() {
     this.location.back();
   }
 
+  ngOnDestroy(): void {
+    // stop updating when this component is destroyed
+    this.unsubscribe();
+  }
+
   ngOnInit() {
     this.job = this.route.snapshot.data['job'];
     this.log = this.route.snapshot.data['log'];
+
+    if (environment.production && this.shouldUpdate()) {
+      this.updateJob();
+    }
+  }
+
+  private updateJob() {
+    this.subscriptions.push(interval(5000)
+      .pipe(
+        startWith(0),
+        switchMap(() => {
+          // keep updating until the job is no longer pending or running
+          if (!this.shouldUpdate()) {
+            this.unsubscribe();
+          }
+          return this.jobService.getJob(this.job.id);
+        })
+      )
+      .subscribe(res => (this.job = res)));
+
+    this.subscriptions.push(interval(5000)
+      .pipe(
+        startWith(0),
+        switchMap(() => {
+          // keep updating until the job is no longer pending or running
+          if (!this.shouldUpdate()) {
+            this.unsubscribe();
+          }
+          return this.logService.getLog(this.job.id);
+        }))
+      .subscribe(res => (this.log = res)));
+  }
+
+  private shouldUpdate(): boolean {
+    return this.job.status === JobStatus.Pending || this.job.status === JobStatus.Running;
+  }
+
+  private unsubscribe(): void {
+    if (this.subscriptions) {
+      this.subscriptions.forEach(sub => {
+        sub.unsubscribe();
+      });
+    }
   }
 }

--- a/src/app/log/log.component.spec.ts
+++ b/src/app/log/log.component.spec.ts
@@ -3,6 +3,7 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { MomentModule } from 'angular2-moment/moment.module';
 import { LogComponent } from './log.component';
+import { LogService } from '../services/log/log.service';
 
 describe('LogComponent', () => {
   let component: LogComponent;
@@ -17,7 +18,8 @@ describe('LogComponent', () => {
         ),
         MomentModule,
         HttpClientTestingModule
-      ]
+      ],
+      providers: [LogService]
     })
       .compileComponents();
   }));

--- a/src/app/project/project.component.spec.ts
+++ b/src/app/project/project.component.spec.ts
@@ -11,6 +11,7 @@ import { ProjectFactory } from '../tests/project-factory';
 import { ProjectComponent } from './project.component';
 
 import * as util from 'util';
+import { BuildService } from '../services/build/build.service';
 
 describe('ProjectComponent', () => {
   let component: ProjectComponent;
@@ -35,6 +36,7 @@ describe('ProjectComponent', () => {
         MomentModule
       ],
       providers: [
+        BuildService,
         {
           provide: ActivatedRoute,
           useValue: {

--- a/src/app/project/project.component.ts
+++ b/src/app/project/project.component.ts
@@ -1,21 +1,26 @@
 import { Location } from '@angular/common';
-import { Component, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
+import { interval, Subscription } from 'rxjs';
 import 'rxjs/add/operator/switchMap';
+import { startWith, switchMap, take } from 'rxjs/operators';
 import { Build } from '../models/build';
 import { Project } from '../models/project';
+import { BuildService } from '../services/build/build.service';
+import { environment } from 'src/environments/environment';
 
 @Component({
   selector: 'app-project',
   templateUrl: './project.component.html',
   styleUrls: ['./project.component.scss']
 })
-export class ProjectComponent implements OnInit {
+export class ProjectComponent implements OnInit, OnDestroy {
   project: Project;
   builds: Build[];
   location: Location;
+  subscriptions: Subscription[] = [];
 
-  constructor(private route: ActivatedRoute, location: Location) {
+  constructor(private route: ActivatedRoute, location: Location, private buildService: BuildService) {
     this.location = location;
   }
 
@@ -23,8 +28,38 @@ export class ProjectComponent implements OnInit {
     this.location.back();
   }
 
+  ngOnDestroy(): void {
+    // stop updating when this component is destroyed
+    this.unsubscribe();
+  }
+
   ngOnInit() {
     this.project = this.route.snapshot.data['project'];
     this.builds = this.route.snapshot.data['builds'];
+
+    if (environment.production) {
+      this.updateBuilds();
+    }
+  }
+
+  private updateBuilds() {
+    this.subscriptions.push(interval(5000)
+      .pipe(
+        startWith(0),
+        switchMap(() => {
+          return this.buildService.getBuilds(this.project.id);
+        })
+      )
+      // stop refreshing the builds after 10 minutes
+      .pipe(take(120))
+      .subscribe(res => (this.builds = res)));
+  }
+
+  private unsubscribe(): void {
+    if (this.subscriptions) {
+      this.subscriptions.forEach(sub => {
+        sub.unsubscribe();
+      });
+    }
   }
 }

--- a/src/app/services/job/job.service.ts
+++ b/src/app/services/job/job.service.ts
@@ -1,6 +1,8 @@
 import { Observable } from 'rxjs/Observable';
 import { Job } from '../../models/job';
+import { Injectable } from '@angular/core';
 
+@Injectable()
 export abstract class JobService {
     abstract getJobs(buildId: string): Observable<Job[]>;
     abstract getJob(jobId: string): Observable<Job>;

--- a/src/app/services/job/mock-job.service.ts
+++ b/src/app/services/job/mock-job.service.ts
@@ -3,7 +3,9 @@ import { Observable } from 'rxjs/Observable';
 import { Jobs } from '../../mock/jobs';
 import { Job } from '../../models/job';
 import { JobService } from './job.service';
+import { Injectable } from '@angular/core';
 
+@Injectable()
 export class MockJobService implements JobService {
   getJobs(buildId: string): Observable<Job[]> {
     return Observable.of(Jobs);

--- a/src/app/services/project/project.service.ts
+++ b/src/app/services/project/project.service.ts
@@ -1,7 +1,9 @@
 import { Observable } from 'rxjs/Observable';
 import { Project } from '../../models/project';
 import { ProjectsBuild } from '../../models/projects-build';
+import { Injectable } from '@angular/core';
 
+@Injectable()
 export abstract class ProjectService {
     abstract getProjectBuilds(): Observable<ProjectsBuild[]>;
     abstract getProject(projectId: string): Observable<Project>;

--- a/src/app/services/resolvers/jobs.resolver.ts
+++ b/src/app/services/resolvers/jobs.resolver.ts
@@ -12,4 +12,3 @@ export class JobsResolver implements Resolve<Job[]> {
     return this.jobService.getJobs(route.paramMap.get('id'));
   }
 }
-


### PR DESCRIPTION
closes #164 
closes #3 

This PR uses observables to poll for changes from the API, meaning users no longer have to refresh the page to get new information.

The polling works as follows:

- for the build and job views, the polling happens for as long as the build / job is in pending or running state. Once they exist this state, the polling stops.
- for the dashboard and project views, the polling happens for 10 minutes.

In all cases, the polling interval is 5 seconds, and it stops whenever a component is destroyed.

I suspect we could further refactor this and avoid having any code related to polling in components themselves, but I would really like to get this into the next release - suggestions are welcome as to refactoring polling into the services / resolvers.
