### PR TITLE
add support for shortTitle and longTitle fields

### DIFF
--- a/src/app/build/build.component.html
+++ b/src/app/build/build.component.html
@@ -10,6 +10,12 @@
             Build &nbsp;
             <em>{{ build.id }}</em>
           </h1>
+          <h1 *ngIf="build.long_title && build.long_title != ''">
+            {{ build.long_title }}
+          </h1>
+          <h1 *ngIf="(!build.long_title || build.long_title == '') && (build.short_title && build.short_title != '')">
+            {{ build.short_title }}
+          </h1>
 
           <div class="build-status">
             <div class="unknown" *ngIf="!build.worker?.status">

--- a/src/app/mock/builds.ts
+++ b/src/app/mock/builds.ts
@@ -8,6 +8,8 @@ export const Builds: Build[] = [
       'brigade-29d38c7477ecee18e184b69bec354fc350605c51bc16d4dd2b6073',
     type: 'push',
     provider: 'github',
+    short_title: 'branch: master',
+    long_title: 'branch: master',
     revision: {
       commit: '3c981a',
       ref: 'master'
@@ -33,6 +35,8 @@ export const Builds: Build[] = [
       'brigade-29d38c7477ecee18e184b69bec354fc350605c51bc16d4dd2b6073',
     type: 'pull_request',
     provider: 'github',
+    short_title: 'PR #42',
+    long_title: 'PR #42: life, the universe, and everything',
     revision: {
       commit: '3c981a',
       ref: 'master'
@@ -58,6 +62,8 @@ export const Builds: Build[] = [
       'brigade-830c16d4aaf6f5490937ad719afd8490a5bcbef064d397411043ac',
     type: 'exec',
     provider: 'github',
+    short_title: '',
+    long_title: '',
     revision: {
       commit: '3c981a',
       ref: 'master'
@@ -81,6 +87,8 @@ export const Builds: Build[] = [
       'brigade-830c16d4aaf6f5490937ad719afd8490a5bcbef064d397411043ac',
     type: 'exec',
     provider: 'brigade-cli',
+    short_title: '',
+    long_title: '',
     revision: {
       commit: '3c981a',
       ref: 'master'
@@ -104,6 +112,8 @@ export const Builds: Build[] = [
       'brigade-830c16d4aaf6f5490937ad719afd8490a5bcbef064d397411043ac',
     type: 'exec',
     provider: 'brigade-cli',
+    short_title: '',
+    long_title: '',
     revision: {
       commit: '3c981a',
       ref: 'master'
@@ -127,6 +137,8 @@ export const Builds: Build[] = [
       'brigade-830c16d4aaf6f5490937ad719afd8490a5bcbef064d397411043ac',
     type: 'exec',
     provider: 'brigade-cli',
+    short_title: '',
+    long_title: '',
     revision: {
       commit: '',
       ref: ''
@@ -150,6 +162,8 @@ export const Builds: Build[] = [
       'brigade-830c16d4aaf6f5490937ad719afd8490a5bcbef064d397411043ac',
     type: 'exec',
     provider: 'github',
+    short_title: '',
+    long_title: '',
     revision: {
       commit: '',
       ref: ''
@@ -173,6 +187,8 @@ export const Builds: Build[] = [
       'brigade-830c16d4aaf6f5490937ad719afd8490a5bcbef064d397411043ac',
     type: 'quicktestX',
     provider: 'brigade-cli',
+    short_title: '',
+    long_title: '',
     revision: {
       commit: '',
       ref: ''
@@ -186,6 +202,8 @@ export const Builds: Build[] = [
       'brigade-830c16d4aaf6f5490937ad719afd8490a5bcbef064d397411043ac',
     type: 'quicktestX',
     provider: 'brigade-cli',
+    short_title: '',
+    long_title: '',
     revision: {
       commit: '',
       ref: ''
@@ -209,6 +227,8 @@ export const Builds: Build[] = [
       'brigade-830c16d4aaf6f5490937ad719afd8490a5bcbef064d397411043ac',
     type: 'exec',
     provider: 'brigade-cli',
+    short_title: '',
+    long_title: '',
     revision: {
       commit: '',
       ref: ''
@@ -232,6 +252,8 @@ export const Builds: Build[] = [
       'brigade-830c16d4aaf6f5490937ad719afd8490a5bcbef064d397411043ac',
     type: 'exec',
     provider: 'brigade-cli',
+    short_title: '',
+    long_title: '',
     revision: {
       commit: '',
       ref: ''

--- a/src/app/models/build.ts
+++ b/src/app/models/build.ts
@@ -6,6 +6,8 @@ export interface Build {
   project_id: string;
   type: string;
   provider: string;
+  short_title: string;
+  long_title: string;
   revision: Revision;
   payload?: string;
   script?: string;

--- a/src/app/project/project.component.html
+++ b/src/app/project/project.component.html
@@ -28,7 +28,12 @@
           <span class="act-type" title="Event Type: {{ build.type }}">
             {{ build.type }}
           </span>
-          <span class="act-message" title="Build ID: {{ build.id }}">
+          <span *ngIf="build.short_title && build.short_title != ''" class="act-message"
+            title="Build ID: {{ build.id }}">
+            {{ build.short_title }}
+          </span>
+          <span *ngIf="!build.short_title || build.short_title == ''" class="act-message"
+            title="Build ID: {{ build.id }}">
             {{ build.id }}
           </span>
 

--- a/src/app/tests/build-factory.ts
+++ b/src/app/tests/build-factory.ts
@@ -7,6 +7,8 @@ export const BuildFactory = Factory.makeFactory<Build>({
   project_id: 'brigade-1234',
   type: 'push',
   provider: 'github',
+  short_title: '',
+  long_title: '',
   revision: {
     commit: '',
     ref: ''


### PR DESCRIPTION
This is a follow-up to:

* https://github.com/brigadecore/brigade/pull/1031
* https://github.com/brigadecore/brigade-github-app/pull/87

In the project view, this will show short titles for individual builds in place of the opaque build IDs _if_ a short title is available. You can still mouse-over the title to see the opaque build ID in a tool tip.

In the build view, the long title for the build will appear under the opaque build ID _if_ a long title is available. If one isn't available, it will fall back on the short title if one is available. If not, then there's no change to this view.

For reviewer convenience, I am attaching screenshots.

<img width="1223" alt="Screen Shot 2019-11-27 at 11 40 07 PM" src="https://user-images.githubusercontent.com/1821014/69777675-54cd3c80-116f-11ea-8674-daf58df6709e.png">

<img width="1285" alt="Screen Shot 2019-11-27 at 11 41 06 PM" src="https://user-images.githubusercontent.com/1821014/69777691-6c0c2a00-116f-11ea-932c-334ec3fce6ff.png">

@radu-matei and @flynnduism, I am admittedly _not_ a front-end developer, so please, please scrutinize this carefully. I am way out of my comfort zone with Angular. Happy to change anything you say needs changing.
