### PR TITLE
Update the Build view to use tabbed logs

### DIFF
--- a/src/app/build/build.component.html
+++ b/src/app/build/build.component.html
@@ -4,7 +4,6 @@
   <div class="grid-content build-header-wrap">
     <div class="grid-block horizontal">
       <div class="small-12">
-
         <div class="build-header">
           <h1>
             Build &nbsp;
@@ -13,28 +12,37 @@
 
           <div class="build-status">
             <div class="unknown" *ngIf="!build.worker?.status">
-              <i class="icon ion-md-radio-button-off"></i> Log Unavailable</div>
+              <i class="icon ion-md-radio-button-off"></i> Log Unavailable
+            </div>
 
             <div class="pending" *ngIf="build.worker?.status == 'Pending'">
-              <div class="spinner"></div> Initializing...
+              <div class="spinner"></div>
+              Initializing...
             </div>
             <div class="running" *ngIf="build.worker?.status == 'Running'">
-              <div class="spinner"></div> Build started...
+              <div class="spinner"></div>
+              Build started...
             </div>
 
             <div class="success" *ngIf="build.worker?.status == 'Succeeded'">
-              <i class="icon ion-md-checkmark-circle"></i> {{ build.worker.status }}</div>
+              <i class="icon ion-md-checkmark-circle"></i>
+              {{ build.worker.status }}
+            </div>
             <div class="failed" *ngIf="build.worker?.status == 'Failed'">
-              <i class="icon ion-md-close-circle"></i> {{ build.worker.status }}</div>
+              <i class="icon ion-md-close-circle"></i> {{ build.worker.status }}
+            </div>
           </div>
 
           <div class="row build-metadata">
-            <div class="small-6 text-left columns">Started at {{ build.worker.start_time }} </div>
-            <div class="small-6 text-right columns">Finished at {{ build.worker.end_time }}</div>
+            <div class="small-6 text-left columns">
+              Started at {{ build.worker.start_time }}
+            </div>
+            <div class="small-6 text-right columns">
+              Finished at {{ build.worker.end_time }}
+            </div>
           </div>
 
           <div class="horizontal build-chart build-chart-1">
-
             <div class="task task-0">
               <a href="">
                 <span title="git">
@@ -45,100 +53,152 @@
 
             <span class="task task-1 task-build-type">{{ build?.type }}</span>
             <span *ngFor="let job of jobs" class="task task-2">
-              <a routerLink="/jobs/{{job?.id}}">{{ job.name }}</a>
+              <a routerLink="/jobs/{{ job?.id }}">{{ job.name }}</a>
             </span>
           </div>
         </div>
-
       </div>
     </div>
   </div>
 
-  <div class="job-list">
-
-    <ul class="build-details" ng-hide="jobs.length == '0'" id="build-details">
-      <li class="parent">
-        <span class="row">
-          <span class="small-9 text-left columns">
-            <span *ngIf="build.provider == 'github'">
-              <i class="icon ion-logo-github"></i>
+  <div class="job-layout-wrap row">
+    <!-- job tabs -->
+    <div class="job-list">
+      <ul class="build-details" ng-hide="jobs.length == '0'" id="build-details">
+        <li class="parent">
+          <span class="row">
+            <span class="small-9 text-left columns">
+              <span *ngIf="build.provider == 'github'">
+                <i class="icon ion-logo-github"></i>
+              </span>
+              <span *ngIf="build.provider == 'slackbot'">
+                <i class="icon ion-text"></i>
+              </span>
+              <span *ngIf="build.provider == 'dockerhub'">
+                <i class="icon ion-cube"></i>
+              </span>
+              <span *ngIf="build.provider == 'brigade-cli'">
+                <em>brigade-cli</em>
+              </span>
+              <em>{{ build.provider }}</em
+              >:
+              <em>{{ build?.type }}</em>
+              started a build via commit
+              <em>{{ build.revision.commit }}</em
+              >.
             </span>
-            <span *ngIf="build.provider == 'slackbot'">
-              <i class="icon ion-text"></i>
+            <span class="small-3 text-right columns jobs-index">
+              <strong>{{ jobs.length }}</strong> jobs ran.
             </span>
-            <span *ngIf="build.provider == 'dockerhub'">
-              <i class="icon ion-cube"></i>
-            </span>
-            <span *ngIf="build.provider == 'brigade-cli'">
-              <em>brigade-cli</em>
-            </span>
-            <em>{{ build.provider }}</em>:
-            <em>{{ build?.type }}</em>
-            started a build via commit
-            <em>{{ build.revision.commit }}</em>.
           </span>
-          <span class="small-3 text-right columns jobs-index">
-            <strong>{{ jobs.length }}</strong> jobs ran.
-          </span>
-        </span>
-      </li>
+        </li>
 
-      <li class="job {{ job?.status | lowercase}}" id="{{ job?.id }}" *ngFor="let job of jobs; index as i"
-        [attr.data-index]="i">
-        <a routerLink="/jobs/{{job?.id}}" title="View log details for {{job?.name}}">
+        <li
+          class="job {{ job?.status | lowercase }}"
+          id="{{ job?.id }}"
+          *ngFor="let job of jobs; index as i"
+          [attr.data-index]="i"
+        >
+          <a
+            routerLink="/jobs/{{ job?.id }}"
+            title="View log details for {{ job?.name }}"
+            class="job-link"
+          >
+            <span class="job-index">{{ i + 1 }}</span>
+            <h5>{{ job?.name }}</h5>
+
+            <!-- job status badge -->
+            <div class="job-response {{ job?.status | lowercase }}">
+              <span
+                class="act-state running"
+                title="{{ job?.status }}"
+                *ngIf="job?.status == 'Active'"
+              >
+                <div class="spinner"></div>
+              </span>
+              <span
+                class="act-state running"
+                title="{{ job?.status }}"
+                *ngIf="job?.status == 'Running'"
+              >
+                <div class="spinner"></div>
+              </span>
+              <span
+                class="act-state running"
+                title="{{ job?.status }}"
+                *ngIf="job?.status == 'Pending'"
+              >
+                <div class="spinner"></div>
+              </span>
+              <span
+                class="act-state succeeded"
+                title="{{ job?.status }}"
+                *ngIf="job?.status == 'Succeeded'"
+              >
+                <i class="icon ion-md-checkmark-circle status-success"></i>
+              </span>
+              <span
+                class="act-state failed"
+                title="{{ job?.status }}"
+                *ngIf="job?.status == 'Failed'"
+              >
+                <i class="icon ion-md-close-circle status-fail"></i>
+              </span>
+              <span
+                class="act-state unknown"
+                title="{{ job?.status }}"
+                *ngIf="job?.status == 'Unknown'"
+              >
+                <i class="icon ion-md-radio-button-off unknown"></i>
+              </span>
+              {{ job?.status }}
+            </div>
+
+            <a class="button rounded secondary"
+              >View Logs
+              <i class="icon ion-md-arrow-dropright"></i>
+            </a>
+          </a>
+        </li>
+
+        <li class="parent parent-end">
+          <span class="row">
+            <span class="small-12 columns">
+              Build {{ build.worker.status | lowercase }} at
+              <em>{{ build.worker.end_time }}</em
+              >.
+            </span>
+          </span>
+        </li>
+      </ul>
+    </div>
+
+    <!-- job tab log area -->
+    <div class="job-tab-content">
+      <ul>
+        <li>
+          <pre>
+            {{ buildlogs.message }}
+          </pre>
+        </li>
+        <li
+          class="job {{ job?.status | lowercase }}"
+          id="{{ job?.id }}"
+          *ngFor="let job of jobs; index as i"
+          [attr.data-index]="i"
+        >
+          <!--
           <small class=" ">Started at {{ job?.start_time }}</small>
-          <span class="job-index">{{i + 1}}</span>
-          <h5>{{job?.name}}</h5>
-
-          <!-- job status badge -->
-          <div class="job-response {{ job?.status | lowercase}}">
-            <span class="act-state running" title="{{ job?.status }}" *ngIf="job?.status == 'Active'">
-              <div class="spinner"></div>
-            </span>
-            <span class="act-state running" title="{{ job?.status }}" *ngIf="job?.status == 'Running'">
-              <div class="spinner"></div>
-            </span>
-            <span class="act-state running" title="{{ job?.status }}" *ngIf="job?.status == 'Pending'">
-              <div class="spinner"></div>
-            </span>
-            <span class="act-state succeeded" title="{{ job?.status }}" *ngIf="job?.status == 'Succeeded'">
-              <i class="icon ion-md-checkmark-circle status-success"></i>
-            </span>
-            <span class="act-state failed" title="{{ job?.status }}" *ngIf="job?.status == 'Failed'">
-              <i class="icon ion-md-close-circle status-fail"></i>
-            </span>
-            <span class="act-state unknown" title="{{ job?.status }}" *ngIf="job?.status == 'Unknown'">
-              <i class="icon ion-md-radio-button-off unknown"></i>
-            </span>
-            {{ job?.status }}
-          </div>
-
           <dl>
             <dt>Image:</dt>
             <dd>{{ job?.image }}</dd>
             <dt>Job ID:</dt>
             <dd>{{ job?.id }}</dd>
           </dl>
-
-          <a class="button rounded secondary">View Logs
-            <i class="icon ion-md-arrow-dropright"></i>
-          </a>
-
           <small class=" ">Finished at {{ job?.end_time }}</small>
-        </a>
-      </li>
-
-      <li class="parent">
-        <span class="row">
-          <span class="small-12 columns">
-            Build {{ build.worker.status | lowercase }} at
-            <em>{{ build.worker.end_time }}</em>.
-          </span>
-          <pre>
-            {{ buildlogs.message }}
-          </pre>
-        </span>
-      </li>
-
-    </ul>
+        --></li>
+      </ul>
+    </div>
+    <!-- job tab log area -->
   </div>
+</div>

--- a/src/app/build/build.component.scss
+++ b/src/app/build/build.component.scss
@@ -1,12 +1,16 @@
-@import '../../global_variables';
-@import '../../global_states';
+@import "../../global_variables";
+@import "../../global_states";
 
 :host {
   min-width: 91.5%;
 }
 
 .build-chart-bg {
-  background: linear-gradient(5deg, darken(#F0F1F6, 2.5%) 0%, lighten(#e6e9f0, 1%) 100%);
+  background: linear-gradient(
+    5deg,
+    darken(#f0f1f6, 2.5%) 0%,
+    lighten(#e6e9f0, 1%) 100%
+  );
   display: block;
   content: " ";
   top: 0;
@@ -28,7 +32,7 @@
 
     .button {
       position: absolute;
-      bottom: -.9rem;
+      bottom: -0.9rem;
       right: 1.75rem;
       transition: none;
       padding-left: 0.75rem;
@@ -88,7 +92,7 @@
       text-transform: uppercase;
 
       &:before {
-        content: '#';
+        content: "#";
       }
     }
 
@@ -163,7 +167,7 @@
       min-width: 2%;
       color: white;
       @include border-radius(0.12rem);
-      @include box-shadow(0, 0.0625rem, 0.2rem,rgba(255,255,255,0.5));
+      @include box-shadow(0, 0.0625rem, 0.2rem, rgba(255, 255, 255, 0.5));
       @include transition;
 
       &:hover {
@@ -300,7 +304,7 @@
 
 ul.build-details {
   list-style: none;
-  margin: 1.5rem auto 3rem;
+  margin: 1.5rem auto 0;
 
   li,
   .accordion-item {
@@ -310,7 +314,7 @@ ul.build-details {
     font-size: 1rem;
     line-height: 1.5;
     border-left: 6px solid lighten($dark1, 42%);
-    @include box-shadow(0, 0.12rem, 0.12rem,rgba(0,0,0,0.125));
+    @include box-shadow(0, 0.12rem, 0.12rem, rgba(0, 0, 0, 0.125));
     @include border-radius(0.25rem);
     margin-left: 1rem;
     color: lighten($dark2, 5%);
@@ -337,6 +341,10 @@ ul.build-details {
   li.parent {
     padding-left: 2.5rem;
     position: relative;
+
+    &.parent-end {
+      margin-bottom: 0;
+    }
 
     .text-left {
       line-height: 2;
@@ -399,7 +407,7 @@ ul.build-details {
       @include nunitoBold;
       color: $dark2;
       font-size: 1.5rem;
-      padding: 0.5em 1.5rem 0 0;
+      padding: 0 1.5rem 0 0;
       float: left;
       margin-left: 0.75rem;
       margin-bottom: 1.125rem;
@@ -408,12 +416,13 @@ ul.build-details {
     .button {
       position: absolute;
       background: $light2;
-      padding: 0.75rem 1rem;
+      padding: 0.25rem 0.75rem 0.25rem 0.5rem;
       border-radius: 0.25rem;
       color: darken($light1, 12.5%);
       line-height: 1;
       top: 50%;
-      right: 5.25rem;
+      right: 1.25rem;
+      font-size: 1rem;
       transform: translateY(-50%);
       @include nunitoBold;
       @include transition;
@@ -481,20 +490,23 @@ ul.build-details {
 
     .job-index {
       position: absolute;
-      top: 1rem;
-      right: 1.25rem;
+      top: 0.3rem;
+      left: 0.35rem;
+      letter-spacing: 0;
       font-weight: bold;
+      font-size: 0.67rem;
     }
 
     .job-response {
       font-size: 0.75rem;
       float: left;
-      background: $light2;
-      margin: 0.75rem 0 0 0;
+      margin: 0.35em 0 0 0;
       padding: 0.25rem 0.75rem 0.25rem 2rem;
       border-radius: 3rem;
       line-height: 1.75;
-      position: relative;
+      position: absolute;
+      top: 3rem;
+      left: 1.125rem;
 
       .icon {
         padding-top: 0;
@@ -514,7 +526,7 @@ ul.build-details {
       }
       &.pending,
       &.running,
-      &.active, {
+      &.active {
         color: $brand2;
 
         .spinner {
@@ -549,7 +561,7 @@ ul.build-details {
     overflow: hidden;
   }
 
-  .log-inner   {
+  .log-inner {
     background: lighten($dark2, 5%);
     position: relative;
     overflow-x: hidden;
@@ -644,5 +656,72 @@ ul.build-details {
 
   .ion-checkmark-circled {
     color: $success;
+  }
+}
+
+.job-layout-wrap {
+  position: relative;
+  min-height: 100%;
+
+  .job-list,
+  .job-tab-content {
+    min-height: 100%;
+  }
+}
+
+.job-list {
+  display: inline-block;
+  width: 30%;
+  float: left;
+
+  .job-link {
+    min-height: 65px;
+    display: inline-block;
+  }
+}
+
+.job-tab-content {
+  display: inline-block;
+  width: 70%;
+  background: white;
+  margin-top: 1.5rem;
+  margin-left: -1px;
+  float: right;
+  z-index: 650;
+  @include box-shadow(0, 0.12rem, 0.12rem, rgba(0, 0, 0, 0.125));
+
+  &::after {
+    position: absolute;
+    display: block;
+    content: " ";
+    top: 0;
+    bottom: 0;
+  }
+
+  pre {
+    border: none;
+    font-family: $mono;
+    margin-top: 0.825rem;
+    color: white;
+    line-height: 1.5;
+    font-size: 0.825rem;
+    display: table-cell;
+    vertical-align: middle;
+    padding-bottom: 0.2em;
+    display: inline-block;
+    max-width: 98.5%;
+    white-space: pre-wrap;
+    white-space: -moz-pre-wrap;
+    white-space: -pre-wrap;
+    white-space: -o-pre-wrap;
+    word-wrap: break-word;
+    @include transition;
+    background: $dark2;
+    color: $light3;
+    padding: 0.5rem 1rem 0;
+    margin-left: 0.75%;
+    margin-right: 0.25%;
+    margin-bottom: 0.5rem;
+    @include border-radius(0.25rem);
   }
 }


### PR DESCRIPTION
Working on #259, this will change the Build view to display the child jobs on one side and the log on the left - creating a more compact UI where you can toggle between the logs via tabs.

- [x] html & css layout edits
- [ ] get angular tabs module working properly
- [ ] change routing for jobs to open tabs rather than new pages 

WIP screenshot:

![Screen Shot 2019-12-06 at 10 45 55 AM](https://user-images.githubusercontent.com/686194/70347585-b3508580-1815-11ea-917f-87a5cc15abf5.png)