### PR TITLE
Order jobs in build

### DIFF
--- a/src/app/services/job/api-job.service.ts
+++ b/src/app/services/job/api-job.service.ts
@@ -6,24 +6,29 @@ import { Job } from '../../models/job';
 import { JobService } from './job.service';
 
 const httpOptions = {
-  headers: new HttpHeaders({ 'Content-Type': 'application/json' })
+  headers: new HttpHeaders({ 'Content-Type': 'application/json' }),
 };
 
 @Injectable()
 export class ApiJobService implements JobService {
-  constructor(private http: HttpClient) { }
+  constructor(private http: HttpClient) {}
 
   getJobs(buildId): Observable<Job[]> {
     const jobsUrl = `${BRIGADE_API_HOST}/v1/build/${buildId}/jobs`;
 
     return this.http
-      .get<Job[]>(jobsUrl, httpOptions);
+      .get<Job[]>(jobsUrl, httpOptions)
+      .map((jobs) =>
+        jobs.sort(
+          (a: Job, b: Job) =>
+            new Date(a.start_time).getTime() - new Date(b.start_time).getTime()
+        )
+      );
   }
 
   getJob(jobId): Observable<Job> {
     const jobUrl = `${BRIGADE_API_HOST}/v1/job/${jobId}`;
 
-    return this.http
-      .get<Job>(jobUrl, httpOptions);
+    return this.http.get<Job>(jobUrl, httpOptions);
   }
 }

--- a/src/app/services/job/mock-job.service.ts
+++ b/src/app/services/job/mock-job.service.ts
@@ -8,12 +8,16 @@ import { Injectable } from '@angular/core';
 @Injectable()
 export class MockJobService implements JobService {
   getJobs(buildId: string): Observable<Job[]> {
-    return Observable.of(Jobs);
+    return Observable.of(Jobs).map((jobs) =>
+      jobs.sort(
+        (a: Job, b: Job) =>
+          new Date(a.start_time).getTime() - new Date(b.start_time).getTime()
+      )
+    );
   }
 
   getJob(jobId: string): Observable<Job> {
-    const filteredList =
-      Jobs.filter((job: Job) => job.id === jobId);
+    const filteredList = Jobs.filter((job: Job) => job.id === jobId);
     return Observable.of(filteredList[0]).delay(500);
   }
 }


### PR DESCRIPTION
closes #294 

This PR returns a sorted observable from the job service, sorted by start date.
Ideally in the future, this should be performed by the API, but until that happens, we can sort client-side.